### PR TITLE
GEN-748: std::runtime_error("") and nam not terminated properly

### DIFF
--- a/manager/src/executables/main.cpp
+++ b/manager/src/executables/main.cpp
@@ -29,8 +29,13 @@
 
 using namespace blaze;
 
+class signal_exception : public std::runtime_error {
+ public:
+  signal_exception(): std::runtime_error("caught signal") {;}
+};
+
 void sigint_handler(int s) {
-  throw std::runtime_error("");
+  throw signal_exception();
 }
 
 int main(int argc, char** argv) {
@@ -88,6 +93,7 @@ int main(int argc, char** argv) {
                  << "' as local directory, using '/tmp' instead.";
   }
 
+  try {
   // setup PlatformManager
   PlatformManager platform_manager(conf);
 
@@ -154,18 +160,17 @@ int main(int argc, char** argv) {
   }
 
   while (1) {
-    try {
-      boost::this_thread::sleep_for(boost::chrono::seconds(5)); 
-      //print_timers();
+    boost::this_thread::sleep_for(boost::chrono::seconds(5)); 
+    //print_timers();
 #ifndef NO_PROFILE
-      if (gf_profile) {
-        ksight::ksight.print(); 
-      }
+    if (gf_profile) {
+      ksight::ksight.print(); 
+    }
 #endif
-    }
-    catch(std::runtime_error const& ) {
-      break;
-    }
+  }
+  } // try
+  catch (std::runtime_error const& ) {
+    VLOG(1) << "Caught signal, cleaning up"; 
   }
 
   return 0;


### PR DESCRIPTION
In one run, nam exits unexpectedly with the following error:
terminate called after throwing an instance of 'std::runtime_error'
what():

This occurs ~20s after the program starts, with hundreds of pairhmm tasks already finished.

Inspection indicates that the exception was thrown after blaze captured an exit signal. But the signal was not handled properly.

As a result, subsequent runs all have the following error: 
Error opening AFC: resource busy
This is because the previous nam was still alive and FPGA resource was not released.

Current fix uses a specific exception for signal handling (`signal_exception`), and wraps entire body of `main()` inside `try..catch` block. The problem is not guaranteed to be fixed, but at least current commit should separate problems, and provides more insight. 